### PR TITLE
Implicitly use encoding from BE bytes only

### DIFF
--- a/lightclient-circuits/src/poseidon.rs
+++ b/lightclient-circuits/src/poseidon.rs
@@ -8,10 +8,7 @@ use halo2_base::{
     poseidon::hasher::PoseidonSponge, AssignedValue, Context, QuantumCell,
 };
 use halo2_ecc::{bigint::ProperCrtUint, bls12_381::FpChip, fields::FieldChip};
-use halo2curves::{
-    bls12_381::{self, Fq},
-    group::UncompressedEncoding,
-};
+use halo2curves::bls12_381::{self, Fq};
 use itertools::Itertools;
 use pse_poseidon::Poseidon as PoseidonNative;
 
@@ -107,7 +104,7 @@ pub fn poseidon_committee_commitment_from_uncompressed(
         .iter()
         .cloned()
         .map(|bytes| {
-            halo2curves::bls12_381::G1Affine::from_uncompressed_unchecked(
+            halo2curves::bls12_381::G1Affine::from_uncompressed_unchecked_be(
                 &bytes.as_slice().try_into().unwrap(),
             )
             .unwrap()

--- a/lightclient-circuits/src/sync_step_circuit.rs
+++ b/lightclient-circuits/src/sync_step_circuit.rs
@@ -38,10 +38,7 @@ use halo2_ecc::{
     },
     fields::FieldChip,
 };
-use halo2curves::{
-    bls12_381::{G1Affine, G2Affine},
-    group::UncompressedEncoding,
-};
+use halo2curves::bls12_381::{G1Affine, G2Affine};
 use itertools::Itertools;
 use num_bigint::BigUint;
 use ssz_rs::Merkleized;
@@ -87,7 +84,7 @@ impl<S: Spec, F: Field> StepCircuit<S, F> {
             .as_slice()
             .iter()
             .map(|bytes| {
-                G1Affine::from_uncompressed_unchecked(&bytes.as_slice().try_into().unwrap())
+                G1Affine::from_uncompressed_unchecked_be(&bytes.as_slice().try_into().unwrap())
                     .unwrap()
             })
             .collect_vec();
@@ -267,7 +264,7 @@ impl<S: Spec, F: Field> StepCircuit<S, F> {
             .as_slice()
             .iter()
             .map(|bytes| {
-                G1Affine::from_uncompressed_unchecked(&bytes.as_slice().try_into().unwrap())
+                G1Affine::from_uncompressed_unchecked_be(&bytes.as_slice().try_into().unwrap())
                     .unwrap()
             })
             .collect_vec();


### PR DESCRIPTION
Implicitly use encoding from BE bytes for BLS12-381 affine points.

> Related to: halo2curves::bls12_381 uses LE everywhere now: https://github.com/timoftime/halo2curves/commit/7afc48bdaddd93e8c2c1c4255443e860dd122399

